### PR TITLE
docs: add feature isolation rule (#6)

### DIFF
--- a/docs/FEATURE_ISOLATION.md
+++ b/docs/FEATURE_ISOLATION.md
@@ -1,0 +1,23 @@
+# Feature Isolation Rule (Project Standard)
+
+To keep the app stable and beginner-friendly, each feature must be independent.
+
+## Allowed imports
+
+A feature in `src/app/features/<feature>/` may import ONLY:
+
+- `src/app/shared/**` (reusable UI / helpers)
+- `src/app/domain/**` (pure models + calculation functions)
+- `src/app/core/**` (storage, audit, guards, utilities)
+
+## Not allowed
+
+- A feature must NOT import another feature directly.
+  Example (❌ not allowed):
+  - `features/month` importing from `features/messes`
+
+## Why
+
+- If one feature breaks, others keep working.
+- Easier debugging + cleaner codebase.
+- Makes Copilot contributions safer.


### PR DESCRIPTION
Closes #6

## What changed
- Added docs/FEATURE_ISOLATION.md to define strict feature isolation rules.

## Why
- Ensures components/features can be developed independently without breaking others.
